### PR TITLE
添加了通用的 upgrade-hook 命令，用于脚本升级

### DIFF
--- a/client/bin/cli.js
+++ b/client/bin/cli.js
@@ -11,6 +11,7 @@ import {
   resetCommand,
   hookVersionCommand,
   updateHookToV3Command,
+  upgradeHookCommand,
   cleanupCommand,
   debugCommand
 } from '../src/commands/index.js';
@@ -75,6 +76,15 @@ program
   .description('Upgrade hook to v3 with optimized performance')
   .option('-f, --force', 'Force upgrade even if already on v3')
   .action(updateHookToV3Command);
+
+// 通用 Hook 升级命令
+program
+  .command('upgrade-hook')
+  .description('Upgrade hook to specified version or latest')
+  .option('--target <version>', 'Target version to upgrade to (v2, v3)', 'v3')
+  .option('-f, --force', 'Force upgrade even if already on target version')
+  .option('-l, --latest', 'Upgrade to latest version including shared modules')
+  .action(upgradeHookCommand);
 
 // 清理状态文件
 program


### PR DESCRIPTION
Introduce comprehensive upgrade-hook command to replace upgrade-to-v3:
- Universal upgrade tool supporting any version (v2/v3) and upgrade paths
- Smart version detection and upgrade path selection
- Auto-install shared modules for d20a85d compatibility
- Backup and recovery mechanism for safe upgrades
- Support for --target, --latest, --force options
- Fix CLI parameter conflict (--version → --target)

Enhanced hook-manager.js:
- Add installSharedModules() for d20a85d shared module support
- Update saveHookVersion() to track latest flag and module features
- Support installation options (force, latest) in installHook()

Updated documentation:
- Comprehensive upgrade guide with scenario-based recommendations
- New FAQ entries explaining upgrade command differences
- Version history updated with d20a85d commit highlights

This enables seamless upgrades from incorrectly installed v3 to full d20a85d-compatible version with shared modules and improved architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)